### PR TITLE
Fix empty page classifier

### DIFF
--- a/classifurlr/classifiers/empty_page.py
+++ b/classifurlr/classifiers/empty_page.py
@@ -1,4 +1,5 @@
 from ..classification import Classifier
+from ..har_utils import get_total_size
 
 class EmptyPageClassifier(Classifier):
     def __init__(self):
@@ -8,6 +9,6 @@ class EmptyPageClassifier(Classifier):
         self.size_cutoff = 300 # bytes
 
     def page_down_confidence(self, page, session):
-        total_size = page.get_total_size(page.entries)
+        total_size = get_total_size(page.entries)
         return 1.0 if total_size <= self.size_cutoff else 0.0
 

--- a/classifurlr/classifiers/throttle.py
+++ b/classifurlr/classifiers/throttle.py
@@ -1,6 +1,7 @@
 import logging
 
 from ..classification import Classifier
+from ..har_utils import get_total_size
 
 class ThrottleClassifier(Classifier):
     def __init__(self):
@@ -12,7 +13,7 @@ class ThrottleClassifier(Classifier):
         self.bandwidth_threshold = 50 # kbps
 
     def page_down_confidence(self, page, session):
-        bites = page.get_total_size(page.entries)
+        bites = get_total_size(page.entries)
         kilobits = bites * 8 / 1000.0
         mss = page.get_load_time()
         seconds = mss / 1000.0

--- a/classifurlr/har_utils.py
+++ b/classifurlr/har_utils.py
@@ -25,3 +25,10 @@ def har_entry_response_content(entry):
         return str(BeautifulSoup(text, 'lxml'))
     except Exception as e:
         raise NotEnoughDataError('Could not parse entry content')
+
+def get_total_size(entries):
+  size = 0
+  for entry in entries:
+    if entry['response']['content']['size'] > 0:
+      size += entry['response']['content']['size']
+  return size

--- a/classifurlr/har_utils.py
+++ b/classifurlr/har_utils.py
@@ -26,6 +26,9 @@ def har_entry_response_content(entry):
     except Exception as e:
         raise NotEnoughDataError('Could not parse entry content')
 
+# Using the size property of the content instead of the bodySize
+# as the latter gets wrong values sometimes for some websites.
+# See https://bugs.chromium.org/p/chromium/issues/detail?id=379130
 def get_total_size(entries):
   size = 0
   for entry in entries:


### PR DESCRIPTION
There is a bug in Chromium and sometimes it returns
wrong values in multiple HAR properties, like here, in
the bodySize field. The content>size property looks much
more reliable.

More info here:
https://bugs.chromium.org/p/chromium/issues/detail?id=379130

Redmine issue:
https://cyber.harvard.edu/projectmanagement/issues/16344